### PR TITLE
fix: remove main branch fetcing for super-linter being able to run on main branch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,9 +15,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          
-      - name: Fetch main branch
-        run: git fetch origin main:main
 
       - name: Lint Code Base
         uses: super-linter/super-linter@v6


### PR DESCRIPTION
При мёрдже предыдущих изменений в main возникла ошибка: линтер падал из-за команды git fetch origin main:main, которая выполнялась прямо в ветке main и вызывала конфликт. В этом PR я удалил лишнюю команду fetch, чтобы устранить эту ошибку.