### PR TITLE
fix: enable validation of all codebase to fix crashes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Lint Code Base
         uses: super-linter/super-linter@v6
         env:
-          VALIDATE_ALL_CODEBASE: false
+          VALIDATE_ALL_CODEBASE: true
           VALIDATE_JAVASCRIPT_ES: true
           VALIDATE_TSX: true
           VALIDATE_TYPESCRIPT_ES: true


### PR DESCRIPTION
Изменил правило валидации, потому что при старом вылетала ошибка при мёрдже кода фронтенда в мейн